### PR TITLE
Modify timeout for Agent Publish, Deploy to 300s, 120s

### DIFF
--- a/teamcity-xldeploy-agent/src/main/java/jetbrains/buildServer/xldeploy/agent/XldDeployBuildProcess.java
+++ b/teamcity-xldeploy-agent/src/main/java/jetbrains/buildServer/xldeploy/agent/XldDeployBuildProcess.java
@@ -43,9 +43,12 @@ public class XldDeployBuildProcess implements BuildProcess {
         final Map<String, String> runnerParameters = context.getRunnerParameters();
 
         logger = runningBuild.getBuildLogger();
-        logger.progressStarted("Progress started for XldDeployBuildProcess");
+        logger.progressStarted("Progress started for XldDeployBuildProcess (120s timeout)");
 
-        client = new OkHttpClient();
+        client = new OkHttpClient.Builder()
+          .readTimeout(120, java.util.concurrent.TimeUnit.SECONDS)
+          .writeTimeout(120, java.util.concurrent.TimeUnit.SECONDS)
+          .build();
 
         host = runnerParameters.get(XldDeployConstants.SETTINGS_XLDDEPLOY_HOST);
         port = Integer.parseInt(runnerParameters.get(XldDeployConstants.SETTINGS_XLDDEPLOY_PORT));

--- a/teamcity-xldeploy-agent/src/main/java/jetbrains/buildServer/xldeploy/agent/XldPublishBuildProcess.java
+++ b/teamcity-xldeploy-agent/src/main/java/jetbrains/buildServer/xldeploy/agent/XldPublishBuildProcess.java
@@ -36,9 +36,12 @@ public class XldPublishBuildProcess implements BuildProcess {
         final Map<String, String> runnerParameters = context.getRunnerParameters();
 
         logger = runningBuild.getBuildLogger();
-        logger.progressStarted("Progress started for XldPublishBuildProcess");
+        logger.progressStarted("Progress started for XldPublishBuildProcess (300s timeout)");
 
-        client = new OkHttpClient();
+        client = new OkHttpClient.Builder()
+          .readTimeout(300, java.util.concurrent.TimeUnit.SECONDS)
+          .writeTimeout(300, java.util.concurrent.TimeUnit.SECONDS)
+          .build();
 
         host = runnerParameters.get(XldPublishConstants.SETTINGS_XLDPUBLISH_HOST);
         port = Integer.parseInt(runnerParameters.get(XldPublishConstants.SETTINGS_XLDPUBLISH_PORT));


### PR DESCRIPTION
Extended connection timeout in order to handle very large artifacts being used by an XLD customer